### PR TITLE
Add basic user authentication

### DIFF
--- a/shopping-list/app/build.gradle
+++ b/shopping-list/app/build.gradle
@@ -23,7 +23,10 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:28.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:4.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/shopping-list/app/src/main/AndroidManifest.xml
+++ b/shopping-list/app/src/main/AndroidManifest.xml
@@ -11,20 +11,24 @@
     <uses-permission android:name="pl.dplewa.shoppinglistapp.permissions.NEW_ENTRY_INTENT" />
 
     <application
-        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".activity.MainActivity"
+            android:name=".activity.AuthenticationActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".activity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
         </activity>
         <activity
             android:name=".activity.SettingsActivity"

--- a/shopping-list/app/src/main/java/pl/dplewa/shoppinglistapp/activity/AuthenticationActivity.java
+++ b/shopping-list/app/src/main/java/pl/dplewa/shoppinglistapp/activity/AuthenticationActivity.java
@@ -1,0 +1,62 @@
+package pl.dplewa.shoppinglistapp.activity;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import com.firebase.ui.auth.AuthUI;
+import com.firebase.ui.auth.IdpResponse;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+
+import java.util.Collections;
+import java.util.List;
+
+import pl.dplewa.shoppinglistapp.R;
+
+/**
+ * @author Dominik Plewa
+ */
+public class AuthenticationActivity extends ThemedActivity {
+
+    private static final int RC_SIGN_IN = 44;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_auth);
+    }
+
+    public void startSignIn(View view) {
+        final List<AuthUI.IdpConfig> authProviders = Collections.singletonList(
+                new AuthUI.IdpConfig.EmailBuilder().build());
+        startActivityForResult(
+                AuthUI.getInstance()
+                        .createSignInIntentBuilder()
+                        .setAvailableProviders(authProviders)
+                        .build(),
+                RC_SIGN_IN);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RC_SIGN_IN) {
+            IdpResponse response = IdpResponse.fromResultIntent(data);
+
+            if (resultCode == RESULT_OK) {
+                // Successfully signed in
+                Intent shoppingListIntent = new Intent(this, MainActivity.class);
+                shoppingListIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                startActivity(shoppingListIntent);
+            } else if (response != null) {
+                // an error occured
+                Toast.makeText(this, "Authentication failed, try again", Toast.LENGTH_LONG).show();
+            } else {
+                // TODO probably nothing? user pressed back button
+            }
+        }
+    }
+}

--- a/shopping-list/app/src/main/res/layout/activity_auth.xml
+++ b/shopping-list/app/src/main/res/layout/activity_auth.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:text="@string/auth.button.signin"
+        android:onClick="startSignIn"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/shopping-list/app/src/main/res/values/strings.xml
+++ b/shopping-list/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="productFormNameValidateToast">Enter the name first</string>
     <string name="productFormPriceValidateToast">Enter the price first</string>
     <string name="productFormCountValidateToast">Enter the count first</string>
+    <string name="auth.button.signin">Sign in</string>
 </resources>

--- a/shopping-list/build.gradle
+++ b/shopping-list/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        
+        classpath 'com.google.gms:google-services:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Resolves #19 .

Users will be requested to sign in before using the shopping list.
For now only standard email + password auth is supported (no integration with Google, Facebook etc.)